### PR TITLE
Serialize tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "babel-node index.js",
     "dev": "nodemon index.js --exec babel-node",
-    "test": "jest",
-    "test:watch": "jest --watch"
+    "test": "jest --runInBand",
+    "test:watch": "jest --watch --runInBand"
   },
   "author": "",
   "license": "ISC",

--- a/src/routes/__tests__/messages.test.js
+++ b/src/routes/__tests__/messages.test.js
@@ -12,7 +12,7 @@ import Message from '../../models/Message'
 const mongoUrl = process.env.MONGO_URL || 'mongodb://127.0.0.1/undefTest'
 
 let server
-const PORT = 3003
+const PORT = 3001
 
 beforeAll(async () => {
   mongoose.connect(mongoUrl, {

--- a/src/routes/__tests__/rooms.test.js
+++ b/src/routes/__tests__/rooms.test.js
@@ -13,7 +13,7 @@ let server
 let TOKEN = ''
 let TOKEN_ALTERNATIVE = ''
 let SECRET = ''
-const PORT = 3002
+const PORT = 3001
 
 // SETUP ALL TEST DATA ETC
 beforeAll(async () => {


### PR DESCRIPTION
added flag runInBand to force tests to run serialized instead of paralllell. Now we can use the same port (3001) for the server at least